### PR TITLE
WAKE_LOCK permission defined twice

### DIFF
--- a/android_code/hello-tango-jni-example/app/src/main/AndroidManifest.xml
+++ b/android_code/hello-tango-jni-example/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
         android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />


### PR DESCRIPTION
Remove the `Warning: Element uses-permission#android.permission.WAKE_LOCK at AndroidManifest.xml:16:5-68 duplicated with element declared at AndroidManifest.xml:12:5-68`
